### PR TITLE
Corrige um Erro ao Executar as Migrations

### DIFF
--- a/db/migrate/20160916212446_add_devise_to_users.rb
+++ b/db/migrate/20160916212446_add_devise_to_users.rb
@@ -16,8 +16,8 @@ class AddDeviseToUsers < ActiveRecord::Migration[5.0]
       t.integer  :sign_in_count, default: 0, null: false
       t.datetime :current_sign_in_at
       t.datetime :last_sign_in_at
-      t.inet     :current_sign_in_ip
-      t.inet     :last_sign_in_ip
+      t.string     :current_sign_in_ip
+      t.string     :last_sign_in_ip
 
       ## Confirmable
       # t.string   :confirmation_token


### PR DESCRIPTION
Olá Leonardo, estava executando seu código e me deparei com um erro ao rodar rake db:migrate

O erro é undefined method inet no arquivo de migração da tabela users do devise. 

Eu alterei o arquivo e o restante está funcionando. 

Obrigado pela atenção.